### PR TITLE
bug fix: zero com cnf output

### DIFF
--- a/ecnf/nets/egnn.py
+++ b/ecnf/nets/egnn.py
@@ -183,7 +183,7 @@ class EGNN(nn.Module):
         if self.residual_x:
             vectors = vectors - initial_vectors
 
-        vectors = vectors - positions.mean(axis=0, keepdims=True)  # Zero-CoM.
+        vectors = vectors - vectors.mean(axis=0, keepdims=True)  # Zero-CoM.
 
         vectors = vectors * self.param("final_scaling", nn.initializers.ones_init(), ())
 


### PR DESCRIPTION
Bug in zero com of egnn output. Will need to re-run all baselines to fix this. 